### PR TITLE
Fix version discrepancies

### DIFF
--- a/content/2.installation/3.manual.md
+++ b/content/2.installation/3.manual.md
@@ -4,8 +4,8 @@
 
 For a manual installation, the following requirements must be met:
 
-- [Node.js 18.14.x](https://nodejs.org/en/download/)
-- [pnpm 7.25.x](https://pnpm.io/installation) or higher
+- [Node.js 20.11.x](https://nodejs.org/en/download/)
+- [pnpm 8.15.x](https://pnpm.io/installation) or higher
 - [Redis 7.x](https://redis.io/download)
 - [MongoDB 5.x](https://www.mongodb.com/try/download/community)
 - [Git](https://git-scm.com/downloads)

--- a/content/5.development/0.index.md
+++ b/content/5.development/0.index.md
@@ -11,7 +11,7 @@ I personally develop on Windows and Linux. If you find that the development setu
 
 For development, you need the following tools installed.
 
-- Node.js >=20.11.x
+- Node.js 20.11.x
 - pnpm >=8.15.x
 
 Of course, the basics like a text editor, git and a terminal are also required.

--- a/content/5.development/0.index.md
+++ b/content/5.development/0.index.md
@@ -11,7 +11,7 @@ I personally develop on Windows and Linux. If you find that the development setu
 
 For development, you need the following tools installed.
 
-- Nodejs >v18.16.x
-- Pnpm >8.7.x
+- Node.js >=20.11.x
+- pnpm >=8.15.x
 
 Of course, the basics like a text editor, git and a terminal are also required.


### PR DESCRIPTION
I noticed that the required versions in the wiki are not the same that are defined in the `package.json`   file.
This fixes the version discrepancy and also the formatting so that the two files that contain the information use the same one for names.