### PR TITLE
Fix ISO 3166-1 country codes link in wiki

### DIFF
--- a/content/3.configuration/1.environment.md
+++ b/content/3.configuration/1.environment.md
@@ -32,4 +32,4 @@ ViewTube will check all required environment variables on startup. Check the log
 | VIEWTUBE\_YOUTUBE\_COOKIE              | _empty_ | Your Youtube cookie (see:[Youtube cookies](/configuration/advanced#use-cookies-from-a-real-account))                                                              |
 | VIEWTUBE\_PROXY\_URL                   | _empty_ | The URL of the proxy server (see:[Proxy](/configuration/advanced#proxy))                                                                                          |
 | VIEWTUBE\_SUBSCRIPTION\_INTERVAL\_TIME | 60      | Specify the time between subscription refreshes in minutes.                                                                                                       |
-| VIEWTUBE\_LOCATION                     | _empty_ | Specify the location for the trending page. For example, "DE" for Germany.[View all country codes.](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) |
+| VIEWTUBE\_LOCATION                     | _empty_ | Specify the location for the trending page. For example, "DE" for Germany.[View all country codes.](https://en.wikipedia.org/wiki/ISO_3166-1#Codes) |


### PR DESCRIPTION
Changed Wikipedia link from 'List of ISO 639 language codes' to 'List of ISO 3166-1 country codes'