### PR TITLE
Fix 'Get started' page text in wiki

### DIFF
--- a/content/1.about/0.index.md
+++ b/content/1.about/0.index.md
@@ -4,5 +4,6 @@ title: Get started
 
 # Using ViewTube
 
-ViewTube is a self-hostable frontend for YouTube. If you do not want to install it yourself, you can use one of the [public instances](/about/instances).\:br
+ViewTube is a self-hostable frontend for YouTube. If you do not want to install it yourself, you can use one of the [public instances](/about/instances).
+
 If you have a server or PC to run it on, check out the [installation guide](/installation).


### PR DESCRIPTION
Removed /:br from line 7, added a blank line 8, pushed second sentence into line 9.